### PR TITLE
Add context menu support for item views

### DIFF
--- a/src/PJ.ContextActions.Maui/PJCollectionViewHandler.android.cs
+++ b/src/PJ.ContextActions.Maui/PJCollectionViewHandler.android.cs
@@ -64,6 +64,8 @@ sealed class PJViewAdapter : ReorderableItemsViewAdapter<ReorderableItemsView, I
 		if (position >= 0 && position < size)
 		{
 			var element = itemsSource.GetItem(position + 1);
+			var contextMenuListener = new ItemContextMenuListener(element);
+			holder.ItemView.SetOnCreateContextMenuListener(contextMenuListener);
 
 		}
 	}


### PR DESCRIPTION
Add context menu support for item views

This commit introduces an `ItemContextMenuListener` for the elements retrieved from the `itemsSource`. The listener is assigned to the `ItemView` of the `holder`, enabling context menu functionality for items at specified positions.